### PR TITLE
Don't double execute queries. Also use $bind array

### DIFF
--- a/core/ODBO.php
+++ b/core/ODBO.php
@@ -556,7 +556,6 @@
 			} catch (\Exception $e){
 				$this->handleDBError($e, $statement);
 			}
-			$statement->execute();
 			$statement->setFetchMode(PDO::FETCH_NUM);
 			$data = $statement->fetchAll(PDO::FETCH_OBJ);
 			
@@ -939,11 +938,10 @@
 				if (preg_match("/^select/i", $sql)) $isSelect = true;
 				$statement = ($forceReader && !empty($this->reader))?$this->reader->prepare($sql):$this->dbh->prepare($sql);
 				try {
-					$result = $statement->execute();
+					$result = $statement->execute($bind);
 				} catch (\Exception $e){
 					$result = $this->handleDBError($e, $statement);
 				}
-                $result = $statement->execute($bind);
                 $this->data = [];
                 if ($isSelect) {
                     $statement->setFetchMode(PDO::FETCH_OBJ);


### PR DESCRIPTION
Looks like a small mistake when adding the `handleDBError` function, in updating the different segments to use the new error handling functionality.