### PR TITLE
Enabling global flag for reader/writer switch.

### DIFF
--- a/core/ODBO.php
+++ b/core/ODBO.php
@@ -42,7 +42,7 @@
         public $dbh;
 		public $enable_system_columns = TRUE;
 		
-		private $shouldUseReader = true;
+		private static $shouldUseReader = true;
 
 	    public function __construct(){
 
@@ -75,6 +75,22 @@
             }
 
 	    }
+
+		/**
+		 * @param bool $shouldUseReader
+		 */
+		public static function setUseReader($shouldUseReader)
+		{
+			static::$shouldUseReader = $shouldUseReader;
+		}
+
+		/**
+		 * @return bool
+		 */
+		public static function getShouldUseReader()
+		{
+			return static::$shouldUseReader;
+		}
 
 	    public function startTransaction(){
 	    	$this->dbh->beginTransaction();
@@ -342,7 +358,7 @@
         	if( empty($this->is_transaction) ){
 				$get_params = array( $this->primary_key_column => $this->dbh->lastInsertId() );
 				if( !empty($option_is_set) ){ $get_params["with"] = "options"; }
-				$this->shouldUseReader = false;
+				static::$shouldUseReader = false;
 				$this->get( $get_params);
 			}
 
@@ -429,7 +445,7 @@
         	if( empty($this->is_transaction) ){
 				$get_params = array($this->primary_key_column=>$params[$this->primary_key_column]);
 				if( !empty($option_is_set) ){ $get_params["with"] = "options"; }
-				$this->shouldUseReader = false;
+				static::$shouldUseReader = false;
 				$this->get( $get_params);
 			}
 			
@@ -548,7 +564,7 @@
 	        $where_str = $this->getWhere($params,$values,$original_params);
 
 	        $this->sql = 'SELECT '.implode(',',$columns).' FROM '.$this->table . $this->getJoin() . $filter_join .$where_str . $order_by . $limit;
-			$statement = (!empty($this->reader) && $this->shouldUseReader)?$this->reader->prepare($this->sql):$this->dbh->prepare($this->sql);
+			$statement = (!empty($this->reader) && static::$shouldUseReader)?$this->reader->prepare($this->sql):$this->dbh->prepare($this->sql);
 			$this->shouldUserReader = true;
 			forEach($values as $value){ if( is_integer($value) ){ $statement->bindValue($value['key'], trim($value['value']), PDO::PARAM_INT); } else { $statement->bindValue($value['key'], trim((string)$value['value']), PDO::PARAM_STR); } }
 			try {


### PR DESCRIPTION
The current implementation of `ODBO::$shouldUseReader` is object specific, not class specific. So:
```
$createUserResponse = $this->route('obray/OUsers/add', ['ouser_email' => 'admin@email.com']);
$freshUser = $this->route('obray/OUsers/get', ['ouser_email' => $createUserResponse->getFirst()->ouser_email])->getFirst();
```

In this scenario, the `$createUserResponse` object is configured to use the writer only (`ODBO::$shouldUseReader === false`). However, `$this->route(...)` instantiates a new instance of some class that inherits from `ODBO`, and since `ODBO::$shouldUseReader` is not static, it is configured to use the reader where possible (`ODBO::$shouldUseReader === true`). This causes the race condition that we've hit a few times.

Switching `ODBO::$shouldUseReader` to `static` means that once it switches, it remains switched for the duration of the PHP process.

There are functions provided to enable setting it specifically, such that a developer who knows that switching the reader back on is safe, they may do so; or if a scenario arises that they know they require writer only, they can disable the reader connection.